### PR TITLE
Remove tokens from logs.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,14 @@
 documentation:
-  - any: ["docs/*"]
+- any: ["docs/*"]
 
 migrations:
-  - any: ["hubuum/migrations/*"]
+- any: ["hubuum/migrations/*"]
 
 dependencies:
-  - any: ["requirements*"]
+- any: ["requirements*"]
 
 testing:
-  - any: ["hubuum/tests/*", "hubuum/api/*/tests/*", "tox.ini"]
+- any: ["hubuum/tests/*", "hubuum/api/*/tests/*", "tox.ini"]
 
 github_actions:
-  - any: [".github/actions/*"]
+- any: [".github/actions/*"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4
+        with:
+          sync-labels: true

--- a/hubuum/api/v1/tests/test_42_logging.py
+++ b/hubuum/api/v1/tests/test_42_logging.py
@@ -216,6 +216,9 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
                 "/api/auth/logout/",
             )
 
+        for i, log in enumerate(cap_logs):
+            print(i, log)
+
         self.assertTrue(len(cap_logs) == 8)
         self._check_events(
             cap_logs,

--- a/hubuum/log.py
+++ b/hubuum/log.py
@@ -5,6 +5,37 @@ import structlog
 logger = structlog.get_logger("hubuum.manual")
 
 
+def _replace_token(token):
+    """Replace a token with a shortened and safe version of it."""
+    if len(token) > 10:
+        return token[:3] + "..." + token[-3:]
+
+    return "..."
+
+
+def _filter_sensitive_data(record):
+    """Filter sensitive data from a log record."""
+    if record is None:
+        return None
+
+    if isinstance(record, dict):
+        for key, value in record.items():
+            if key in ["token"]:
+                record[key] = _replace_token(value)
+            else:
+                record[key] = _filter_sensitive_data(value)
+    elif record and isinstance(record, str) and '"token":"' in record:
+        token = record.split('"token":"')[1].split('"')[0]
+        record = record.replace(token, _replace_token(token))
+
+    return record
+
+
+def filter_sensitive_data(_, __, event_dict):
+    """Filter sensitive data from a structlogs event_dict."""
+    return _filter_sensitive_data(event_dict)
+
+
 def debug(message, **kwargs):
     """Log a debug message."""
     logger.debug(message, **kwargs)

--- a/hubuumsite/settings.py
+++ b/hubuumsite/settings.py
@@ -19,6 +19,8 @@ import sentry_sdk
 import structlog
 from structlog_sentry import SentryProcessor
 
+import hubuum.log
+
 LOGGING_LEVEL = os.environ.get("HUBUUM_LOGGING_LEVEL", "critical").upper()
 LOGGING_LEVEL_SOURCE = {}
 
@@ -219,6 +221,7 @@ elif SENTRY_LEVEL == "CRITICAL":
 
 structlog.configure(
     processors=[
+        hubuum.log.filter_sensitive_data,
         structlog.stdlib.filter_by_level,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,


### PR DESCRIPTION
Fixes #82

  - Impemented by adding a structlog processor to do the filtering.
  - Note that structlog processors are *not* active when using capture_log()
  - When using capture_log() during testing, one will thus see tokens.