### PR TITLE
Log object deletion when affected by cascade or directly from the object.

### DIFF
--- a/hubuum/api/v1/views.py
+++ b/hubuum/api/v1/views.py
@@ -78,13 +78,12 @@ class LoggingMixin:
 
     def _log(self, operation, model, user, instance):
         """Write the log string."""
-        logger = structlog.get_logger("hubuum.object")
+        logger = structlog.get_logger("hubuum.api.object")
         logger.info(
-            "object_change",
-            operation=operation,
+            operation,
             model=model,
             user=str(user),
-            instance=str(instance),
+            instance=instance.id,
         )
 
     def perform_create(self, serializer):
@@ -93,7 +92,7 @@ class LoggingMixin:
         instance = serializer.instance
         if instance:
             self._log(
-                "create", instance.__class__.__name__, self.request.user, instance
+                "created", instance.__class__.__name__, self.request.user, instance
             )
 
     def perform_update(self, serializer):
@@ -102,12 +101,12 @@ class LoggingMixin:
         instance = serializer.instance
         if instance:
             self._log(
-                "update", instance.__class__.__name__, self.request.user, instance
+                "updated", instance.__class__.__name__, self.request.user, instance
             )
 
     def perform_destroy(self, instance):
         """Log deletes."""
-        self._log("delete", instance.__class__.__name__, self.request.user, instance)
+        self._log("deleted", instance.__class__.__name__, self.request.user, instance)
         super().perform_destroy(instance)
 
 

--- a/hubuum/log.py
+++ b/hubuum/log.py
@@ -19,11 +19,17 @@ def _filter_sensitive_data(record):
         return None
 
     if isinstance(record, dict):
+        if "model" in record and record["model"] == "AuthToken":
+            value = record["id"]
+            (token, username) = value.split(" : ")
+            record["id"] = _replace_token(token) + " : " + username
+
         for key, value in record.items():
             if key in ["token"]:
                 record[key] = _replace_token(value)
             else:
                 record[key] = _filter_sensitive_data(value)
+
     elif record and isinstance(record, str) and '"token":"' in record:
         token = record.split('"token":"')[1].split('"')[0]
         record = record.replace(token, _replace_token(token))

--- a/hubuum/middleware/logging_http.py
+++ b/hubuum/middleware/logging_http.py
@@ -69,6 +69,6 @@ class LogHttpResponseMiddleware:
             path=request.path_info,
             content=content,
             run_time_ms=round(run_time_ms, 2),
-        ).log(log_level, "HTTP response")
+        ).log(log_level, "response")
 
         return response

--- a/hubuum/signals.py
+++ b/hubuum/signals.py
@@ -8,9 +8,11 @@ from django.contrib.auth.signals import (
     user_logged_out,
     user_login_failed,
 )
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 user_logger = structlog.getLogger("hubuum.auth")
+object_logger = structlog.getLogger("hubuum.signals.object")
 
 
 def _log_user_event(
@@ -24,6 +26,29 @@ def _log_user_event(
     user_logger.bind(id=user_label).log(level, event)
 
 
+def _identifier(instance):
+    """Return an identifier for an instance."""
+    if hasattr(instance, "id"):
+        return instance.id
+    return str(instance)
+
+
+@receiver(post_save)
+def log_object_creation(sender, instance, created, **kwargs):
+    """Log object creation."""
+    identifier = _identifier(instance)
+    if created:
+        object_logger.bind(model=sender.__name__, id=identifier).info("created")
+    else:
+        object_logger.bind(model=sender.__name__, id=identifier).info("updated")
+
+
+@receiver(post_delete)
+def log_object_deletion(sender, instance, **kwargs):
+    """Log object deletion."""
+    object_logger.bind(model=sender.__name__, id=_identifier(instance)).info("deleted")
+
+
 @receiver(user_logged_in)
 def log_user_login(sender, user, **kwargs):
     """Log user logins."""
@@ -33,7 +58,7 @@ def log_user_login(sender, user, **kwargs):
 @receiver(user_login_failed)
 def log_user_login_failed(sender, user=None, **kwargs):
     """Log user login failures."""
-    _log_user_event(sender, user, "login failed", level=logging.ERROR)
+    _log_user_event(sender, user, "failure", level=logging.ERROR)
 
 
 @receiver(user_logged_out)

--- a/hubuumsite/settings.py
+++ b/hubuumsite/settings.py
@@ -24,7 +24,7 @@ import hubuum.log
 LOGGING_LEVEL = os.environ.get("HUBUUM_LOGGING_LEVEL", "critical").upper()
 LOGGING_LEVEL_SOURCE = {}
 
-for source in ["DJANGO", "OBJECT", "REQUEST", "MANUAL", "AUTH"]:
+for source in ["DJANGO", "API", "SIGNALS", "REQUEST", "MANUAL", "AUTH"]:
     LOGGING_LEVEL_SOURCE[source] = os.environ.get(
         f"HUBUUM_LOGGING_LEVEL_{source}", LOGGING_LEVEL
     ).upper()
@@ -260,9 +260,14 @@ LOGGING = {
             "handlers": ["console"],
             "level": LOGGING_LEVEL_SOURCE["DJANGO"],
         },
-        "hubuum.object": {
+        "hubuum.api.object": {
             "handlers": ["console"],
-            "level": LOGGING_LEVEL_SOURCE["OBJECT"],
+            "level": LOGGING_LEVEL_SOURCE["API"],
+            "propagate": False,
+        },
+        "hubuum.signals.object": {
+            "handlers": ["console"],
+            "level": LOGGING_LEVEL_SOURCE["SIGNALS"],
             "propagate": False,
         },
         "hubuum.request": {


### PR DESCRIPTION
Fixes #80

NOTE: Loggers have changed names due to signals:
  - hubuum.object is now hubuum.api.object
  - object modifications from signals goes to hubuum.signals.object

The environment variables involved have also changed as HUBUUM_LOGGING_LEVEL_OBJECT has been replaced by HUBUUM_LOGGING_LEVEL_API and HUBUUM_LOGGING_LEVEL_SIGNALS. If we want only object creation signals, we're out of luck. For now.

  - Adds signals for tracking object modifications.
  - Changes a bit of logging output syntax.
  - Filters out token values from the AuthToken string id.