### PR TITLE
Create docker images.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,128 @@
+name: Docker test, build, and (optionally) push
+
+on:
+  push:
+    branches:
+      - main
+      - "*"
+  release:
+    types:
+      - published
+  schedule:
+    - cron: "15 3 * * 6"
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          tags: hubuum:${{ matrix.platform }}
+          build-args: |
+            ENVIRONMENT=testing
+          load: true
+
+  test-images:
+    needs: build-images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: github_actions
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    env:
+      HUBUUM_DATABASE_USER: postgres
+      HUBUUM_DATABASE_PASSWORD: postgres
+      HUBUUM_DATABASE_NAME: github_actions
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Run tests
+        run: docker run -e MODE=testing hubuum:${{ matrix.platform }}
+
+  push-images:
+    needs: test-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: terjekv
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: terjekv
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            terjekv/hubuum
+            ghcr.io/terjekv/hubuum
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=latest
+            type=raw,value=develop,enable=${{ endsWith(GitHub.ref, 'refs/heads/main') }}
+
+      - name: Rebuild Docker images without testing environment
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: hubuum:rebuild
+          load: true
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM python:3.11-alpine as builder
+WORKDIR /opt/hubuum
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+ARG ENVIRONMENT="production"
+RUN apk update
+RUN apk add --virtual build-deps gcc python3-dev musl-dev libffi-dev postgresql-dev
+
+COPY requirements*.txt /opt/hubuum/
+RUN mkdir /opt/hubuum/wheels
+RUN pip install --upgrade pip
+RUN if [ "$ENVIRONMENT" = "testing" ] ; then \
+        pip wheel --no-cache-dir --wheel-dir /opt/hubuum/wheels -r requirements-test.txt; \
+    else \
+        pip wheel --no-cache-dir --wheel-dir /opt/hubuum/wheels -r requirements.txt; \
+    fi
+
+# Final stage
+FROM python:3.11-alpine
+EXPOSE 8099
+ENV PYTHONUNBUFFERED 1
+
+ARG ENVIRONMENT="production"
+COPY requirements*.txt entrypoint.sh manage.py /app/
+COPY hubuum /app/hubuum/
+COPY hubuumsite /app/hubuumsite/
+
+COPY --from=builder /opt/hubuum/wheels /wheels
+
+RUN apk update && apk upgrade && apk add --no-cache  python3 py3-pip  libstdc++ postgresql-libs \
+    && pip install --upgrade pip \
+    && pip install --no-cache /wheels/* \
+    && rm -rf /wheels
+
+
+WORKDIR /app
+CMD ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ ENV PYTHONUNBUFFERED 1
 
 ARG ENVIRONMENT="production"
 RUN apk update
+RUN apk upgrade
 RUN apk add --virtual build-deps gcc python3-dev musl-dev libffi-dev postgresql-dev
 
 COPY requirements*.txt /opt/hubuum/
 RUN mkdir /opt/hubuum/wheels
-RUN pip install --upgrade pip
 RUN if [ "$ENVIRONMENT" = "testing" ] ; then \
         pip wheel --no-cache-dir --wheel-dir /opt/hubuum/wheels -r requirements-test.txt; \
     else \
@@ -29,11 +29,11 @@ COPY hubuumsite /app/hubuumsite/
 
 COPY --from=builder /opt/hubuum/wheels /wheels
 
-RUN apk update && apk upgrade && apk add --no-cache  python3 py3-pip  libstdc++ postgresql-libs \
-    && pip install --upgrade pip \
-    && pip install --no-cache /wheels/* \
-    && rm -rf /wheels
-
+RUN apk update
+RUN apk upgrade
+RUN apk add --no-cache python3 py3-pip libstdc++ postgresql-libs
+RUN pip install --no-cache /wheels/*
+RUN rm -rf /wheels
 
 WORKDIR /app
 CMD ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Exit on error
+set -e
+
+MODE="${MODE:-production}"
+
+# Run Django migrations
+python manage.py migrate 
+
+# pass signals on to the gunicorn process
+function sigterm()
+{
+	echo "Received SIGTERM"
+	kill -term `cat /var/run/gunicorn.pid`
+}
+trap sigterm SIGTERM
+
+export DJANGO_SETTINGS_MODULE=hubuumsite.settings
+
+# Run tests if in testing mode
+if [ "$MODE" = "testing" ]; then
+    # Run Django test suite
+    exec python manage.py test --noinput --failfast
+else
+    export HUBUUM_LOGGING_PRODUCTION=true
+    # Start the application using Gunicorn, store its PID, set the worker temporary directory, and wait for it to terminate
+    gunicorn hubuumsite.wsgi:application --workers=3 --bind 0.0.0.0:8099 --pid /var/run/gunicorn.pid --worker-tmp-dir /dev/shm --log-level error &
+    wait $!
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ python manage.py migrate
 function sigterm()
 {
 	echo "Received SIGTERM"
-	kill -term `cat /var/run/gunicorn.pid`
+	kill -term $( cat /var/run/gunicorn.pid )
 }
 trap sigterm SIGTERM
 

--- a/hubuumsite/settings.py
+++ b/hubuumsite/settings.py
@@ -241,7 +241,7 @@ structlog.configure(
 
 LOGGING = {
     "version": 1,
-    "disable_existing_loggers": False,
+    "disable_existing_loggers": True,
     "formatters": {
         "console": {
             "()": structlog.stdlib.ProcessorFormatter,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ django_filter==23.2
 django-structlog==5.1.0
 knox==0.1.14
 
+gunicorn==20.1.0
+
 rich==13.3.5 # Used for console logging.
 
 sentry-sdk[django]==1.22.1

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,54 @@ allowlist_externals =
     mkdocs
     python
 
+[testenv:docker]
+setenv =
+    DJANGO_SETTINGS_MODULE=hubuumsite.settings
+
+passenv = HUBUUM_*, GITHUB_*
+
+# Docker may require IP and not a hostname, as DNS may or may not work as intended.
+commands =
+    docker build -t hubuum_local_test --build-arg ENVIRONMENT=testing .
+    docker run -e MODE=testing \
+        -e HUBUUM_DATABASE_NAME="{env:HUBUUM_DATABASE_NAME}" \
+        -e HUBUUM_DATABASE_USER="{env:HUBUUM_DATABASE_USER}" \
+        -e HUBUUM_DATABASE_PASSWORD="{env:HUBUUM_DATABASE_PASSWORD}" \
+        -e HUBUUM_DATABASE_PORT="{env:HUBUUM_DATABASE_PORT}" \
+        -e HUBUUM_DATABASE_HOST="{env:HUBUUM_DATABASE_HOST_IP}" \
+        -p 8099:8099 hubuum_local_test 
+
+allowlist_externals = 
+    docker
+
+[testenv:dockerx]
+setenv = 
+    DJANGO_SETTINGS_MODULE=hubuumsite.settings
+
+passenv = HUBUUM_*, GITHUB_*
+
+commands = 
+    docker buildx build --platform linux/amd64 -t hubuum:amd64-latest-testing --build-arg ENVIRONMENT=testing --progress plain --load -f Dockerfile .
+    docker buildx build --platform linux/arm64 -t hubuum:arm64-latest-testing --build-arg ENVIRONMENT=testing --progress plain --load -f Dockerfile .
+
+    docker run -e MODE=testing \
+        -e HUBUUM_DATABASE_NAME="{env:HUBUUM_DATABASE_NAME}" \
+        -e HUBUUM_DATABASE_USER="{env:HUBUUM_DATABASE_USER}" \
+        -e HUBUUM_DATABASE_PASSWORD="{env:HUBUUM_DATABASE_PASSWORD}" \
+        -e HUBUUM_DATABASE_PORT="{env:HUBUUM_DATABASE_PORT}" \
+        -e HUBUUM_DATABASE_HOST="{env:HUBUUM_DATABASE_HOST_IP}" \
+        -p 8099:8099 hubuum:amd64-latest-testing
+    
+    docker run -e MODE=testing \
+        -e HUBUUM_DATABASE_NAME="{env:HUBUUM_DATABASE_NAME}" \
+        -e HUBUUM_DATABASE_USER="{env:HUBUUM_DATABASE_USER}" \
+        -e HUBUUM_DATABASE_PASSWORD="{env:HUBUUM_DATABASE_PASSWORD}" \
+        -e HUBUUM_DATABASE_PORT="{env:HUBUUM_DATABASE_PORT}" \
+        -e HUBUUM_DATABASE_HOST="{env:HUBUUM_DATABASE_HOST_IP}" \
+        -p 8099:8099 hubuum:arm64-latest-testing
+
+allowlist_externals =
+    docker
 
 #whitelist_externals = make
 #commands = make doc spelling


### PR DESCRIPTION
Fixes #89

  - Adds a working Dockerfile.
    - Dockerfile allows for two different builds, test and prod.
    - Controlled by setting ENVIRONMENT=testing
    - ENVIRONMENT defaults to prod.
    - When running the test container, again set ENVIRONMENT=testing.
  - Adds docker and dockerx (multi-platform) test environments to tox.
    - Uses ENVIRONMENT=testing as per above.
  - Adds gunicorn to requirements for production.
  - Adds an entrypoint for the container for both environments.
  - Adds a github action to build containers, for:
    - releases, kept stable. Tagged with the release semver and :latest.
    - pushes / merges to main, and once a week anyway without pushes. Tagged with hash and the latest is :develop
    - For other branches, tagged with branch.

Other changes:
  - Removes Django loggers not part of structlog.