### PR TITLE
Enable SQLite as a testing option.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ Hubuum supports [Sentry](https://sentry.io) for log tracking. The following envi
 
 ## Database Access
 
-- `HUBUUM_DATABASE_BACKEND`: Sets the database backend. Defaults to "django.db.backends.postgresql".
+- `HUBUUM_DATABASE_ENGINE`: Sets the database engine. Defaults to "django.db.backends.postgresql".
 - `HUBUUM_DATABASE_NAME`: Sets the name of the database. Defaults to "hubuum".
 - `HUBUUM_DATABASE_USER`: Sets the database user. Defaults to "hubuum".
 - `HUBUUM_DATABASE_PASSWORD`: Sets the password for the database user. Defaults to `None`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,3 +16,38 @@ Before you submit a pull request, please make sure the following is done:
 2. Check that the tests pass and code style is valid by running `tox -e format` and `tox -e flake8`.
 3. Check that coverage is 100% by running `tox -e coverage` and then `coverage report -m`.
 
+### Local testing
+
+If you have both postgresql and sqlite available locally, you can run the complete test suite by issuing `tox`. The default environment list is rather large (see `tox -l`). You can also test against only one of them. Ideally you want to set your "default" engine setup by using the same enviroment variables as one uses under production:
+
+- `HUBUUM_DATABASE_ENGINE`: Sets the database engine. Defaults to "django.db.backends.postgresql".
+- `HUBUUM_DATABASE_NAME`: Sets the name of the database. Defaults to "hubuum".
+- `HUBUUM_DATABASE_USER`: Sets the database user. Defaults to "hubuum".
+- `HUBUUM_DATABASE_PASSWORD`: Sets the password for the database user. Defaults to `None`.
+- `HUBUUM_DATABASE_HOST`: Sets the database host. Defaults to "localhost".
+- `HUBUUM_DATABASE_PORT`: Sets the port for the database. Defaults to 5432.
+
+#### Postgresql
+
+You MUST specify the following variables for postgresql, even when using tox to ask for a postgresql enviroment (ie, `python310-django41-postgres`). The database name and engine will however be automatically set.
+
+- `HUBUUM_DATABASE_USER` 
+- `HUBUUM_DATABASE_PASSWORD` 
+- `HUBUUM_DATABASE_HOST` 
+- `HUBUUM_DATABASE_PORT` 
+
+You can see the available sqlite environments by doing `tox -l | grep postgres`.
+
+You can run the postgresql suite by itself by doing `tox -e $( tox -l | grep postgres | tr '\n' ',' )`.
+
+#### SQLite 
+
+No configuration is required when using Tox and asking for an sqlite environment. The database will be created in `{envtmpdir}/hubuum.db`, typically something like ` .tox/python310-django41-sqlite/tmp`, and it will be deleted after use. The engine will be automaticall set.
+
+You can see the available sqlite environments by doing `tox -l | grep sqlite`.
+
+You can run the SQLite suite by itself by doing `tox -e $( tox -l | grep sqlite | tr '\n' ',' )`.
+
+### Coverage
+
+Coverage (`tox -e coverage && tox -e report`) assumes that local 

--- a/hubuum/api/v1/tests/base.py
+++ b/hubuum/api/v1/tests/base.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Union
 # because the latter only supportes Z for UTC in python 3.11.
 # https://github.com/python/cpython/issues/80010
 from dateutil.parser import isoparse
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.http import HttpResponse
@@ -26,6 +27,18 @@ class HubuumAPITestCase(APITestCase):  # pylint: disable=too-many-public-methods
         self.user = None
         self.namespace = None
         self.client = self.get_superuser_client()
+
+    def db_engine(self) -> str:
+        """Return the database engine."""
+        return settings.DATABASES["default"]["ENGINE"]
+
+    def db_engine_is_sqlite(self) -> bool:
+        """Return True if the engine is sqlite."""
+        return self.db_engine() == "django.db.backends.sqlite3"
+
+    def db_engine_is_postgresql(self) -> bool:
+        """Return True if the engine is postgresql."""
+        return self.db_engine() == "django.db.backends.postgresql"
 
     def get_superuser_client(self) -> APIClient:
         """Get a client for a superuser."""

--- a/hubuum/api/v1/tests/test_00_internals.py
+++ b/hubuum/api/v1/tests/test_00_internals.py
@@ -45,3 +45,10 @@ class APITokenAuthenticationTestCase(HubuumAPITestCase):
 
         with pytest.raises(AssertionError):
             self.assert_list_contains(["a", "b", "c"], lambda x: x == "d")
+
+    def test_db_introspection(self):
+        """Test that we have some semblance of consistency in our DB introspection."""
+        self.assertTrue(
+            True in [self.db_engine_is_postgresql(), self.db_engine_is_sqlite()]
+        )
+        self.assertFalse(self.db_engine_is_postgresql() and self.db_engine_is_sqlite())

--- a/hubuum/api/v1/tests/test_40_filters.py
+++ b/hubuum/api/v1/tests/test_40_filters.py
@@ -1,8 +1,6 @@
 """Test the filter interface."""
 from typing import Any, Dict
 
-from django.conf import settings
-
 from hubuum.models.auth import User
 from hubuum.models.permissions import Namespace
 from hubuum.models.resources import Host, Room
@@ -123,7 +121,7 @@ class HubuumFilterTestCase(HubuumAPITestCase):
         # https://docs.djangoproject.com/en/4.2/ref/databases/#sqlite-string-matching
         # (Arguments about case sensitivity in domain names emails not withstanding,
         # this is a test of the filter)
-        if settings.DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3":
+        if self.db_engine_is_sqlite():  # pragma: no cover
             self.assert_get_elements("/iam/users/?email__endswith=com", 1)
         else:
             self.assert_get_elements("/iam/users/?email__endswith=com", 0)

--- a/hubuum/migrations/0001_initial.py
+++ b/hubuum/migrations/0001_initial.py
@@ -9,7 +9,6 @@ import hubuum.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/hubuumsite/settings.py
+++ b/hubuumsite/settings.py
@@ -218,7 +218,7 @@ REST_KNOX = {
 DATABASES = {
     "default": {
         "ENGINE": os.environ.get(
-            "HUBUUM_DATABASE_BACKEND", "django.db.backends.postgresql"
+            "HUBUUM_DATABASE_ENGINE", "django.db.backends.postgresql"
         ),
         "NAME": os.environ.get("HUBUUM_DATABASE_NAME", "hubuum"),
         "USER": os.environ.get("HUBUUM_DATABASE_USER", "hubuum"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,18 @@
 [tox]
 minversion = 4
 skip_missing_interpreters = true
+toxworkdir = {env:TOX_WORKDIR:.tox}
 envlist =
     format
     flake8
     coverage
     docs
-    python{37,38,39,310}-django32
-    python{38,39,310}-django40
-    python{39,310,311}-django41
-    python{39,310,311}-django42
+    python{37,38,39,310}-django32-{sqlite,postgres}
+    python{38,39,310}-django40-{sqlite,postgres}
+    python{39,310,311}-django41-{sqlite,postgres}
+    python{39,310,311}-django42-{sqlite,postgres}
 #    examples
 #    linkcheck
-
-toxworkdir = {env:TOX_WORKDIR:.tox}
 
 [gh-actions]
 python =
@@ -48,7 +47,17 @@ deps =
 commands = flake8 hubuum/ hubuumsite/
 
 [testenv]
-setenv = DJANGO_SETTINGS_MODULE=hubuumsite.settings
+description = Run tests against {envname}.
+setenv =
+    DJANGO_SETTINGS_MODULE = hubuumsite.settings
+    HUBUUM_DATABASE_NAME = hubuum
+    postgres: HUBUUM_DATABASE_ENGINE = django.db.backends.postgresql
+    postgres: HUBUUM_TESTING_PARALLEL = 2
+#    mysql: HUBUUM_DATABASE_ENGINE = django.db.backends.mysql
+#    mysql: HUBUUM_TESTING_PARALLEL = 2
+    sqlite: HUBUUM_DATABASE_ENGINE = django.db.backends.sqlite3
+    sqlite: HUBUUM_DATABASE_NAME = {envtmpdir}/hubuum.db
+    sqlite: HUBUUM_TESTING_PARALLEL = auto
 passenv = HUBUUM_*, GITHUB_*
 basepython =
     python37: python3.7
@@ -64,15 +73,17 @@ deps =
     django41: Django>=4.1,<4.2
     django42: Django>=4.2.a1,<4.3
 allowlist_externals = pytest
-commands = pytest -n auto {toxinidir}/hubuum/tests/ {toxinidir}/hubuum/api/v1/tests/
+commands = pytest -n "{env:HUBUUM_TESTING_PARALLEL}" {toxinidir}/hubuum/tests/ {toxinidir}/hubuum/api/v1/tests/
 
 [testenv:clean]
+description = Remove coverage data
 deps = coverage
 skip_install = true
 allowlist_externals = coverage
 commands = coverage erase
 
 [testenv:coverage]
+description = Generate coverage data
 setenv = DJANGO_SETTINGS_MODULE=hubuumsite.settings
 passenv = HUBUUM_*, GITHUB_*
 deps = -r{toxinidir}/requirements-test.txt
@@ -81,12 +92,14 @@ allowlist_externals = coverage
 commands = coverage run --source hubuum --module pytest hubuum
 
 [testenv:report]
+description = Report coverage data
 deps = -r{toxinidir}/requirements-test.txt
 skip_install = true
 allowlist_externals = pytest
 commands = coverage report -m
 
 [testenv:docs]
+description = Build documentation
 setenv =
     API_VERSION=1
     FILE=docs/hubuum-api-v{env:API_VERSION}.json
@@ -105,6 +118,7 @@ allowlist_externals =
     python
 
 [testenv:docker]
+description = Build docker container and run tests in it
 setenv = DJANGO_SETTINGS_MODULE=hubuumsite.settings
 passenv = HUBUUM_*, GITHUB_*
 # Docker may require IP and not a hostname, as DNS may or may not work as intended.
@@ -120,6 +134,7 @@ commands =
         -p 8099:8099 hubuum_local_test 
 
 [testenv:dockerx]
+description = Build docker container and run tests in it, but with buildx and multiarch
 setenv = DJANGO_SETTINGS_MODULE=hubuumsite.settings
 passenv = HUBUUM_*, GITHUB_*
 allowlist_externals = docker


### PR DESCRIPTION
Fixes #142

  - Adds support for SQLite in tox and tests.
  - One issue is that SQLite filters are case insensitive so tests are a bit iffy. This is only a matter in tests though, using SQLIte in prod? I hope not.
  - Change HUBUUM_DATABASE_BACKEND to HUBUUM_DATABASE_ENGINE (maps better to django names)
  - Update documentation.
  - Update migrations (black added a line, no other changes)