### PR TITLE
fix(config): Don't force the db password to be set

### DIFF
--- a/hubuum/tests/test_01_configuration_management.py
+++ b/hubuum/tests/test_01_configuration_management.py
@@ -10,7 +10,10 @@ from django.test import TestCase
 
 from hubuumsite.config.abstract import valid_logging_levels
 from hubuumsite.config.base import HubuumBaseConfig
+from hubuumsite.config.database import HubuumDatabaseConfig
 from hubuumsite.config.logging import HubuumLoggingConfig
+from hubuumsite.config.request import HubuumRequestConfig
+from hubuumsite.config.sentry import HubuumSentryConfig
 
 
 class HubuumBaseConfigTestCase(TestCase):
@@ -28,9 +31,15 @@ class HubuumBaseConfigTestCase(TestCase):
         )
 
     def test_empty_configuration(self) -> None:
-        """Test without any configuration. Defaults to postgres, needs a passowrd."""
-        with pytest.raises(ValueError):
-            HubuumBaseConfig({})
+        """Test without any configuration. Defaults to postgres."""
+        config = HubuumBaseConfig({})
+        self.assertIsNotNone(config)
+        self.assertIsInstance(config, HubuumBaseConfig)
+        self.assertIsInstance(config.logging, HubuumLoggingConfig)
+        self.assertIsInstance(config.database, HubuumDatabaseConfig)
+        self.assertIsInstance(config.sentry, HubuumSentryConfig)
+        self.assertIsInstance(config.requests, HubuumRequestConfig)
+        self.assertEqual(config.database.get("ENGINE"), "django.db.backends.postgresql")
 
     def test_production_vs_developement(self) -> None:
         """Test the mode of operation."""

--- a/hubuumsite/config/database.py
+++ b/hubuumsite/config/database.py
@@ -30,8 +30,3 @@ class HubuumDatabaseConfig(HubuumAbstractConfig):
                     f"Supported engines: {HubuumDatabaseConfig.SUPPORTED_ENGINES}"
                 )
             )
-
-        if engine != "django.db.backends.sqlite3":
-            if not self.get("PASSWORD"):
-                fq_key = self.fq_key("PASSWORD")
-                raise ValueError(f"Database password must be set in {fq_key}.")


### PR DESCRIPTION
There are plenty of commands that work on an empty configuration. We can either allow the default error to be raised when a missing password is required, or guees what needs it and when. This PR opts for the former, the default behaviour.

Closes #154