### PR TITLE
fix(testing): Ensure testing leaves nothing behind

### DIFF
--- a/hubuum/api/v1/tests/test_31_attachments.py
+++ b/hubuum/api/v1/tests/test_31_attachments.py
@@ -511,36 +511,7 @@ class HubuumAttachmentBasicTestCase(HubuumAttachmentTestCase):
                     )
 
 
-class TesttearDownModuleTestCase(HubuumAPITestCase):
-    """Test case for global teardown of this module."""
-
-    def test_teardown_with_folders(self):
-        """Test teardown with folders."""
-        with open("attachments/file/test.txt", "w", encoding="utf-8") as file:
-            file.write("Hello, world!")
-        _cleanup_attachment_directories()
-
-    def test_teardown_without_folders(self):
-        """Test teardown without folders."""
-        # Run twice to ensure we have no folders to delete.
-        _cleanup_attachment_directories()
-        _cleanup_attachment_directories()
-
-
-def _cleanup_attachment_directories() -> None:
-    """Cleanup the attachments directories."""
-    _cleanup_directory("attachments")
-    _cleanup_directory("attachments/file")
-
-
-def _cleanup_directory(directory: str) -> None:
-    """Cleanup the attachments directory."""
-    try:
-        os.rmdir(directory)
-    except OSError:
-        pass
-
-
-def tearDownModule():  # pylint: disable=invalid-name
+def tearDownModule():  # pylint: disable=invalid-name # pragma: no cover
     """Global teardown for this test module, cleans up attachments directory."""
-    _cleanup_attachment_directories()
+    for file in os.scandir("attachments/file/"):
+        os.remove(file.path)


### PR DESCRIPTION
Under GitHub Actions we sometimes get attachment deletion failures
in sqlite environment.

Removing only the attachments and not the folders is a bit safer in
general, and removing the testing of the tearDownModule removes
race conditions when running with high parallelization, which is
probably why this was only seen during sqlite testing.

Closes #156