### PR TITLE
feat(logging): Refactoring and request body logging.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,8 @@ For detailed information on logging, see the [logging documentation](logging.md)
 
 - `HUBUUM_LOGGING_LEVEL`: Sets the default logging level for all sources. Defaults to "CRITICAL".
 - `HUBUUM_LOGGING_PRODUCTION`: Determines if logging is in production mode or not. In production we get no colored output and the JSON layout is compact. Defaults to `False`. Note that if `HUBUUM_SECRET_KEY` was set above, this defaults to `True`, but may be overridden explicitly. 
+- `HUBUUM_LOGGING_MAX_BODY_SIZE`: Sets the maximum size for the logging of the request.body. Defaults to 3k.
+- `HUBUUM_LOGGING_COLLAPSE_REQUEST_ID`: *Only applies to rich console output, never applies for production logging*. If set to True, collapse request_ids to `xxx...xxx` to save some screen real estate. Defaults to True.
 
 ### Individual loggers 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,35 +37,19 @@ These are all the loggers for Hubuum. Their logging levels can be individually s
 !!! note
     `HUBUUM_LOGGING_LEVEL_DJANGO` is the default structlog Django logger but provides very little functionality for Hubuum. Due to this, this logger requires explicit logging levels to be set. Setting `HUBUUM_LOGGING_LEVEL` will *NOT* transfer this logging level to this logger. In the future, this logger may be disabled completely.
 
-| Source      | Description                                                 | Events                            | Fields                                                                |
-| ----------- | ----------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------- |
-| `AUTH`      | Authentication events                                       | login, logout, failure            | id, request_id                                                        |
-| `API`       | API actions such as direct object manipulation              | created, deleted, updated         | id, model, user, request_id                                           |
-| `DJANGO`    | Structlog default Django request loggers                    | request_started, request_finished | request, user_agent / request, code                                   |
-| `INTERNAL`  | Internal events in Hubuum                                   | Undefined                         | Any                                                                   |
-| `MANUAL`    | Manual log events                                           | manual                            | Any                                                                   |
-| `MIGRATION` | On startup database migrations, logged at the `DEBUG` level | created                           | id, model, request_id                                                 |
-| `REQUEST`   | Requests                                                    | request                           | content, method, proxy_ip, remote_ip, request_id, request_size        |
-| `RESPONSE`  | Request responses                                           | response                          | content, method, run\_time\_ms, status_code, status_label, request_id |
-| `SIGNALS`   | Signals, such as object manipulation                        | created, deleted, updated         | id, model, request_id                                                 |
+| Source      | Description                                                 | Events                            | Fields                                                                                                               |
+| ----------- | ----------------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `AUTH`      | Authentication events                                       | login, logout, failure            | id, request_id                                                                                                       |
+| `API`       | API actions, including direct object manipulation           | created, deleted, updated         | id, model, user, request_id                                                                                          |
+| `DJANGO`    | Structlog default Django request loggers                    | request_started, request_finished | request, user_agent / request, code                                                                                  |
+| `INTERNAL`  | Internal events in Hubuum                                   | Undefined                         | Any                                                                                                                  |
+| `MANUAL`    | Manual log events                                           | manual                            | Any                                                                                                                  |
+| `MIGRATION` | On startup database migrations, logged at the `DEBUG` level | created                           | id, model, request_id                                                                                                |
+| `HTTP`      | HTTP requests and responses                                 | request, response                 | content, method, proxy_ip, remote_ip, request_id, request_size, run\_time\_ms, status_code, status_label, request_id |
+| `OBJECT`    | Object manipulation                                         | created, updated, deleted         | request_id, user, model ++                                                                                           |
+| `SIGNAL`    | Signals                                                     | undefined                         | Any                                                                                                                  |
 
-Why both `API` and `SIGNALS`? `API` gives us user information, as it is gathered from the View itself, but this will only log the direct effect of the requested API call. Ie, deleting a Host will be quite similar between the two loggers:
-
-````json
-2023-05-23T10:56:53.420831Z [info ] deleted [hubuum.api.object] instance=1 model=Host user=tmp request_id=28926c59-68c9-4ae6-913b-766d321df69c
-2023-05-23T10:56:53.422447Z [info ] deleted [hubuum.signals.object] id=1 model=Host request_id=28926c59-68c9-4ae6-913b-766d321df69c
-````
-
-However, if one deletes a Namespace, which causes a cascade on the items within, it looks quite different:
-
-````json
-2023-05-23T10:56:53.356191Z [info ] deleted [hubuum.api.object] instance=1 model=Namespace user=superuser request_id=400d5fa1-fe05-41c9-81eb-d6dcedbe155d
-2023-05-23T10:56:53.363781Z [info ] deleted [hubuum.signals.object] id=1 model=Permission request_id=400d5fa1-fe05-41c9-81eb-d6dcedbe155d
-2023-05-23T10:56:53.364163Z [info ] deleted [hubuum.signals.object] id=1 model=Host request_id=400d5fa1-fe05-41c9-81eb-d6dcedbe155d
-2023-05-23T10:56:53.364577Z [info ] deleted [hubuum.signals.object] id=1 model=Namespace request_id=400d5fa1-fe05-41c9-81eb-d6dcedbe155d
-````
-
-Here, the `API` logger only sees the direct effect, the deletion of the Namespace itself, whilst `SIGNAL` also notifies us about the cascaded objects. To get a quick overview of the logging output, one can run a test with logging set to debug:
+To get a quick overview of the logging output, one can run a test with logging set to debug:
 
 ````bash
 HUBUUM_LOGGING_LEVEL=DEBUG pytest hubuum/api/v1/tests/test_20_hosts.py -vv -s

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -16,9 +16,10 @@ One may also set the logging level for specific sources. The following environme
 
 - `HUBUUM_LOGGING_LEVEL_API`: Sets the logging level for the API. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
 - `HUBUUM_LOGGING_LEVEL_AUTH`: Sets the logging level for authentication. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
-- `HUBUUM_LOGGING_LEVEL_SIGNALS`: Sets the logging level for signals, typically used for object manipulation. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
-- `HUBUUM_LOGGING_LEVEL_RESPONSE`: Sets the logging level for responses. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
-- `HUBUUM_LOGGING_LEVEL_REQUEST`: Sets the logging level for requests. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
+- `HUBUUM_LOGGING_LEVEL_HTTP`: Sets the logging level for HTTP traffic, typically requests and responses. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
+- `HUBUUM_LOGGING_LEVEL_OBJECT`: Sets the logging level for object manipulation. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
+- `HUBUUM_LOGGING_LEVEL_SIGNAL`: Sets the logging level for signals, typically used for object manipulation. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
+- `HUBUUM_LOGGING_LEVEL_INTERNAL`: Sets the logging level for internal logging, typically used for introspection. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
 - `HUBUUM_LOGGING_LEVEL_MANUAL`: Sets the logging level for manual logs. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
 - `HUBUUM_LOGGING_LEVEL_MIGRATION`: Sets the logging level for migration logs. Defaults to the value of `HUBUUM_LOGGING_LEVEL`.
 - `HUBUUM_LOGGING_LEVEL_DJANGO`: Sets the logging level for Django. Defaults to `ERROR`. This logger is not recommended for use.
@@ -27,20 +28,22 @@ One may also set the logging level for specific sources. The following environme
 
 Hubuum applies a request_id to contextually related log entries. This request_id follows events from a request to a response, leading to logs such as these:
 
-```json
-2023-07-20T23:13:17.676391Z [debug ] request  [hubuum.request] method=PATCH path=/api/v1/resources/hosts/yes proxy_ip= remote_ip=127.0.0.1 request_id=402cfc7c-f8de-42d6-8f4e-6bbb7dd0b39c request_size=12 user_agent=
-2023-07-20T23:13:17.714942Z [info  ] updated  [hubuum.signals.object] id=8 model=Host request_id=402cfc7c-f8de-42d6-8f4e-6bbb7dd0b39c
-2023-07-20T23:13:17.715166Z [info  ] updated  [hubuum.api.object] instance=8 model=Host request_id=402cfc7c-f8de-42d6-8f4e-6bbb7dd0b39c user=tmp
-2023-07-20T23:13:17.715638Z [debug ] response [hubuum.response] content={...} method=PATCH path=/api/v1/resources/hosts/yes request_id=402cfc7c-f8de-42d6-8f4e-6bbb7dd0b39c run_time_ms=39.25 status_code=200 status_label=OK user=tmp
-2023-07-20T23:13:17.735291Z [debug ] request  [hubuum.request] method=DELETE path=/api/v1/iam/namespaces/namespace1 proxy_ip= remote_ip=127.0.0.1 request_id=65b430d5-e8ec-45dd-90de-4fb4732b132b request_size=0 user_agent=
-2023-07-20T23:13:17.752319Z [info  ] deleted  [hubuum.api.object] instance=7 model=Namespace request_id=65b430d5-e8ec-45dd-90de-4fb4732b132b user=superuser
-2023-07-20T23:13:17.811455Z [info  ] deleted  [hubuum.signals.object] id=4 model=Permission request_id=65b430d5-e8ec-45dd-90de-4fb4732b132b
-2023-07-20T23:13:17.815491Z [info  ] deleted  [hubuum.signals.object] id=8 model=Host request_id=65b430d5-e8ec-45dd-90de-4fb4732b132b
-2023-07-20T23:13:17.818405Z [info  ] deleted  [hubuum.signals.object] id=7 model=Namespace request_id=65b430d5-e8ec-45dd-90de-4fb4732b132b
-2023-07-20T23:13:17.818837Z [debug ] response [hubuum.response] content=[] method=DELETE path=/api/v1/iam/namespaces/namespace1 request_id=65b430d5-e8ec-45dd-90de-4fb4732b132b run_time_ms=83.53 status_code=204 status_label=No Content user=superuser
+```
+2023-07-23T21:16:30.863144Z [info     ]  • request          [hubuum.http] request_id=a07...2f4 method=PATCH remote_ip=127.0.0.1 proxy_ip= user_agent= path=/api/v1/resources/hosts/yes request_size=12 body={"serial":1}
+2023-07-23T21:16:30.896036Z [info     ]  • updated          [hubuum.object] request_id=a07...2f4 model=Host id=1
+2023-07-23T21:16:30.896433Z [debug    ]  • updated          [hubuum.api] request_id=a07...2f4 model=Host user=tmp instance=1
+2023-07-23T21:16:30.896900Z [info     ]  • response         [hubuum.http] request_id=a07...2f4 user=tmp method=PATCH status_code=200 status_label=OK path=/api/v1/resources/hosts/yes content={"id":1,"created_at":"2023-07-23T21:16:30.725568Z","updated_at":"2023-07-23T21:16:30.892566Z","name":"yes","fqdn":"","serial":"1","registration_date":"2023-07-23T21:16:30.725586Z","namespace":1,"type":null,"room":null,"jack":null,"purchase_order":null,"person":null} run_time_ms=33.75
+2023-07-23T21:16:30.908318Z [info     ]  • updated          [hubuum.object] request_id=98f...8d2 model=User id=1
+2023-07-23T21:16:30.912440Z [info     ]  • created          [hubuum.object] request_id=98f...8d2 model=AuthToken id=2ec...aa0 : superuser
+2023-07-23T21:16:30.913254Z [info     ]  • request          [hubuum.http] request_id=98f...8d2 method=DELETE remote_ip=127.0.0.1 proxy_ip= user_agent= path=/api/v1/iam/namespaces/namespace1 request_size=0 body=
+2023-07-23T21:16:30.928717Z [debug    ]  • deleted          [hubuum.api] request_id=98f...8d2 model=Namespace user=superuser instance=1
+2023-07-23T21:16:30.980427Z [info     ]  • deleted          [hubuum.object] request_id=98f...8d2 model=Permission id=1
+2023-07-23T21:16:30.984305Z [info     ]  • deleted          [hubuum.object] request_id=98f...8d2 model=Host id=1
+2023-07-23T21:16:30.987523Z [info     ]  • deleted          [hubuum.object] request_id=98f...8d2 model=Namespace id=1
+2023-07-23T21:16:30.987982Z [info     ]  • response         [hubuum.http] request_id=98f...8d2 user=superuser method=DELETE status_code=204 status_label=No Content path=/api/v1/iam/namespaces/namespace1 content= run_time_ms=74.71
 ```
 
-Notice how the request_id also applies to the cascading events caught by the signals logger and caused by the deletion of the namespace "namespace1".
+Notice how the request_id also applies to the cascading events caused by the deletion of the namespace "namespace1". Also note that the dots would be colored according to the request_id for the entry.
 
 ## Sentry
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,5 +1,12 @@
 # Logging
 
+## Core logging options
+
+- `HUBUUM_LOGGING_LEVEL`: Sets the default logging level for all sources. Defaults to "CRITICAL".
+- `HUBUUM_LOGGING_PRODUCTION`: Determines if logging is in production mode or not. In production we get no colored output and the JSON layout is compact. Defaults to `False`. Note that if `HUBUUM_SECRET_KEY` is set above, this defaults to `True`, but may be overridden explicitly. 
+- `HUBUUM_LOGGING_MAX_BODY_SIZE`: Sets the maximum size for the logging of the request.body. Defaults to 3k.
+- `HUBUUM_LOGGING_COLLAPSE_REQUEST_ID`: *Only applies to rich console output, never applies for production logging*. If set to True, collapse request_ids to `xxx...xxx` to save some screen real estate. Defaults to True.
+
 ## Standard Logging
 
 Hubuum logs to the console as per the [12-factor app](https://12factor.net/logs) methodology.

--- a/hubuum/api/v1/tests/test_42_logging.py
+++ b/hubuum/api/v1/tests/test_42_logging.py
@@ -13,10 +13,78 @@ from structlog.testing import capture_logs
 from structlog.types import EventDict
 
 from hubuum.api.v1.tests.base import HubuumAPITestCase
-from hubuum.log import critical, debug, error, info, warning
+from hubuum.log import (
+    add_request_id,
+    collapse_request_id,
+    critical,
+    debug,
+    error,
+    info,
+    reorder_keys_processor,
+    warning,
+)
 from hubuum.middleware.logging_http import LogHttpResponseMiddleware
 from hubuum.models.iam import HubuumModel, Namespace, User
 from hubuum.models.resources import Host
+
+
+class HubuumLoggingProcessorTestCase(HubuumAPITestCase):
+    """Test that our processors are doing their job."""
+
+    def test_add_request_id_processor(self) -> None:
+        """Test that the request ID is added properly."""
+        # Simulate a series of logging events
+        events = [
+            {"event": "Event 1"},
+            {"event": "Event 2"},
+            {"event": "Event 3"},
+        ]
+        processed_events = []
+
+        # Process each event
+        for event in events:
+            processed_event = add_request_id(None, None, event)
+            processed_events.append(processed_event)
+
+        # Check that the request ID has been added and is the same for all events
+        request_ids: List[str] = [event["request_id"] for event in processed_events]
+        self.assertEqual(len(set(request_ids)), 1)
+
+    def test_reorder_keys_processor(self) -> None:
+        """Test that the keys are reordered properly."""
+        # Simulate a logging event
+        event = {
+            "event": "Event 1",
+            "request_id": "request_id",
+            "another_key": "value",
+        }
+
+        # Process the event
+        processed_event = reorder_keys_processor(None, None, event)
+
+        # Check that request_id is the first key
+        first_key = next(iter(processed_event.keys()))
+        self.assertEqual(first_key, "request_id")
+
+    def test_collapse_request_id_processor(self) -> None:
+        """Test that the request ID is collapsed properly."""
+        testcases: List[Tuple[str, str]] = [
+            ("", "..."),  # length 0
+            ("12345", "..."),  # length 5
+            ("1234567890", "..."),  # length 10
+            ("12345678901", "123...901"),  # length 11
+            ("12345678901234567890", "123...890"),  # length 20
+        ]
+
+        for original_request_id, expected_request_id in testcases:
+            # Simulate a logging event
+            event = {"event": "Event 1", "request_id": original_request_id}
+
+            # Process the event
+            processed_event = collapse_request_id(None, None, event)
+
+            # Check that the request ID has been replaced and properly formatted
+            self.assertEqual(processed_event["request_id"], expected_request_id)
 
 
 class HubuumLoggingTestCase(HubuumAPITestCase):
@@ -64,16 +132,6 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
         self.assertEqual(log["event"], "request_finished")
         self.assertEqual(log["request"], method_and_expected_path)
         self.assertEqual(log["code"], code)
-
-    def _check_request_response_uuids(self, cap_logs: EventDict) -> None:
-        """Check that the request and response have the same UUID."""
-        uuids = []
-        for log in cap_logs:
-            if log["event"] == "request" or log["event"] == "response":
-                uuids.append(log["request_id"])
-
-        # All UUIDs should be the same. Collapse the list to a set to check.
-        self.assertEqual(len(set(uuids)), 1)
 
     def _check_request(
         self,
@@ -158,11 +216,10 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
 
         self.assertEqual(len(cap_logs), 4)
 
-        self._check_request_response_uuids(cap_logs)
         self._check_events(
             cap_logs, ["request_started", "request", "response", "request_finished"]
         )
-        self._check_levels(cap_logs, ["info", "debug", "debug", "info"])
+        self._check_levels(cap_logs, ["info", "info", "info", "info"])
         self._check_request_started(cap_logs[0], "GET /api/v1/iam/namespaces/")
         self._check_request(cap_logs[1], "GET", "/api/v1/iam/namespaces/")
         self._check_response(cap_logs[2], "GET", "/api/v1/iam/namespaces/", 200, "OK")
@@ -182,11 +239,10 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
             self.assert_get_and_404("/iam/namespaces/nope")
 
         self.assertEqual(len(cap_logs), 4)
-        self._check_request_response_uuids(cap_logs)
         self._check_events(
             cap_logs, ["request_started", "request", "response", "request_finished"]
         )
-        self._check_levels(cap_logs, ["info", "debug", "warning", "info"])
+        self._check_levels(cap_logs, ["info", "info", "warning", "info"])
         self._check_request_started(cap_logs[0], "GET /api/v1/iam/namespaces/nope")
         self._check_request(cap_logs[1], "GET", "/api/v1/iam/namespaces/nope")
         self._check_response(
@@ -217,9 +273,7 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
             ],
         )
 
-        self._check_request_response_uuids(cap_logs)
-
-        self._check_levels(cap_logs, ["info", "debug", "info", "info", "debug", "info"])
+        self._check_levels(cap_logs, ["info", "info", "info", "debug", "info", "info"])
 
         self._check_request_started(cap_logs[0], "POST /api/v1/resources/hosts/")
         self._check_request(cap_logs[1], "POST", "/api/v1/resources/hosts/")
@@ -307,17 +361,17 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
             cap_logs,
             [
                 "info",
-                "debug",
                 "info",
                 "info",
                 "info",
-                ["debug", "warning", "critical", "error"],
+                "info",
+                ["info", "warning", "critical", "error"],
                 "info",
                 "info",
-                "debug",
                 "info",
                 "info",
-                "debug",
+                "info",
+                "info",
                 "info",
             ],
         )
@@ -365,7 +419,7 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
         )
         self._check_levels(
             cap_logs,
-            ["info", "debug", "error", ["warning", "critical", "error"], "info"],
+            ["info", "info", "error", ["warning", "critical", "error"], "info"],
         )
 
         self.assertIsNone(cap_logs[2]["id"])
@@ -389,8 +443,8 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
 
         # test the behavior of the logging system with different delays
         delay_responses: List[Tuple[float, str]] = [
-            (0.1, "debug"),
-            (0.5, "debug"),
+            (0.1, "info"),
+            (0.5, "info"),
             (1.0, "warning"),
             (2.0, "warning"),
             (5.0, "error"),
@@ -444,3 +498,27 @@ class HubuumLoggingTestCase(HubuumAPITestCase):
             request.META["HTTP_X_FORWARDED_FOR"] = "192.0.2.0"  # set a proxy IP
             middleware(request)
             self.assertEqual(cap_logs[0]["proxy_ip"], "192.0.2.0")
+
+    def test_binary_request_body(self) -> None:
+        """Test logging of a request with a binary body."""
+        middleware = LogHttpResponseMiddleware(MagicMock())
+
+        def mock_get_response(_):
+            return HttpResponse(status=200)
+
+        middleware.get_response = mock_get_response
+
+        with capture_logs() as cap_logs:
+            get_logger().bind()
+            request = HttpRequest()
+            request._read_started = False
+            request.user = User.objects.get(username="superuser")
+
+            # Mock a binary request body
+            binary_body = b"\x80abc\x01\x02\x03\x04\x05"
+            request._stream = io.BytesIO(binary_body)
+
+            middleware(request)
+
+            # Check that the body was logged as '<Binary Data>'
+            self.assertEqual(cap_logs[0]["body"], "<Binary Data>")

--- a/hubuum/api/v1/views/base.py
+++ b/hubuum/api/v1/views/base.py
@@ -10,11 +10,10 @@ from rest_framework import generics, serializers
 from rest_framework.exceptions import NotFound
 from rest_framework.schemas.openapi import AutoSchema
 
-from hubuum.middleware.context import get_request_id
 from hubuum.permissions import NameSpace
 from hubuum.typing import typed_user_from_request
 
-object_logger = structlog.get_logger("hubuum.api.object")
+object_logger = structlog.get_logger("hubuum.api")
 
 
 class LoggingMixin:
@@ -27,9 +26,8 @@ class LoggingMixin:
         self, operation: str, model: str, user: AbstractUser, instance: Model
     ) -> None:
         """Write the log string."""
-        object_logger.info(
+        object_logger.debug(
             operation,
-            request_id=get_request_id(),
             model=model,
             user=str(user),
             instance=instance.id,

--- a/hubuum/api/views.py
+++ b/hubuum/api/views.py
@@ -1,10 +1,16 @@
 """Non-versioned views for hubuum."""
 
+from typing import Any
+
+from django.http import HttpRequest
 from knox.views import LoginView as KnoxLoginView
 from knox.views import LogoutAllView as KnoxLogoutAllView
 from knox.views import LogoutView as KnoxLogoutView
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.schemas.openapi import AutoSchema
+from structlog import get_logger
+
+logger = get_logger("hubuum.auth")
 
 # Note, we set schemas simply to ensure that openapi is generated correctly.
 
@@ -22,6 +28,13 @@ class LoginView(KnoxLoginView):
     )
 
     authentication_classes = [BasicAuthentication]
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any):
+        """Log the user in."""
+        auth_data = request.META.get("HTTP_AUTHORIZATION", "")
+
+        logger.debug("login_data", input=auth_data)
+        return super().post(request, *args, **kwargs)
 
 
 class LogoutView(KnoxLogoutView):

--- a/hubuum/log.py
+++ b/hubuum/log.py
@@ -1,12 +1,16 @@
 """Logging tools for hubuum."""
 
+from collections import defaultdict
 from functools import singledispatch
 from typing import Any
 
+from rich.console import Console
+from rich.text import Text
 from structlog import get_logger
-from structlog.typing import EventDict
+from structlog.types import EventDict
 
 from hubuum.exceptions import InvalidParam
+from hubuum.middleware.context import get_request_id
 
 logger = get_logger("hubuum.manual")
 
@@ -78,6 +82,27 @@ def filter_sensitive_data(_: Any, __: Any, event_dict: EventDict) -> EventDict:
     return _filter_sensitive_data(event_dict)
 
 
+def add_request_id(_: Any, __: Any, event_dict: EventDict) -> EventDict:
+    """Add the request_id to the event."""
+    event_dict["request_id"] = get_request_id()
+    return event_dict
+
+
+def collapse_request_id(_: Any, __: Any, event_dict: EventDict) -> EventDict:
+    """Collapse request_id into the event."""
+    event_dict["request_id"] = _replace_token(event_dict["request_id"])
+    return event_dict
+
+
+def reorder_keys_processor(_: Any, __: Any, event_dict: EventDict) -> EventDict:
+    """Reorder keys in a structlogs event_dict, ensuring that request_id is first."""
+    event_dict = {
+        k: event_dict[k]
+        for k in sorted(event_dict.keys(), key=lambda k: k != "request_id")
+    }
+    return event_dict
+
+
 def debug(message: str, **kwargs: Any) -> None:
     """Log a debug message."""
     logger.debug(message, **kwargs)
@@ -101,3 +126,63 @@ def error(message: str, **kwargs: Any) -> None:
 def critical(message: str, **kwargs: Any) -> None:
     """Log a critical message."""
     logger.critical(message, **kwargs)
+
+
+class RequestColorTracker:
+    """Add an easy to track colored bubbles based on an events request_id.
+
+    :ivar COLORS: A list of color names to use for the bubbles.
+    :ivar request_to_color: A dictionary mapping request_ids to colors.
+    """
+
+    COLORS = ["red", "white", "green", "yellow", "blue", "magenta", "cyan"]
+
+    def __init__(self):
+        """Initialize a new RequestColorizer.
+
+        Sets the initial mapping of request_ids to colors to be an empty defaultdict.
+        """
+        self.console = Console()
+        self.request_to_color = defaultdict(self._color_generator().__next__)
+
+    def _colorize(self, color: str, s: str) -> str:
+        """Colorize a string using Rich.
+
+        :param color: The name of the color to use.
+        :param s: The string to colorize.
+        :return: The colorized string.
+        """
+        text = Text(s, style=f"bold {color}")
+
+        with self.console.capture() as capture:
+            self.console.print(text)
+
+        output = capture.get()
+
+        return output.rstrip()  # remove trailing newline
+
+    def _color_generator(self):
+        """Create a generator that cycles through the colors.
+
+        :yield: A color from the COLORS list.
+        """
+        i = 0
+        while True:
+            yield self.COLORS[i % len(self.COLORS)]
+            i += 1
+
+    def __call__(self, _: Any, __: Any, event_dict: EventDict) -> EventDict:
+        """Add a colored bubble to the event message.
+
+        :param _: The logger instance. This argument is ignored.
+        :param __: The log level. This argument is ignored.
+        :param event_dict: The event dictionary of the log entry.
+        :return: The modified event dictionary.
+        """
+        request_id = event_dict.get("request_id", "None")
+        color = self.request_to_color[request_id]
+        colored_bubble = self._colorize(color, " • ")
+
+        event_dict["event"] = colored_bubble + event_dict.get("event", "")
+
+        return event_dict

--- a/hubuum/signals.py
+++ b/hubuum/signals.py
@@ -14,12 +14,11 @@ from django.db.models import Model
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from hubuum.middleware.context import get_request_id
 from hubuum.models.core import Attachment
 from hubuum.models.iam import User
 
 user_logger = structlog.getLogger("hubuum.auth")
-object_logger = structlog.getLogger("hubuum.signals.object")
+object_logger = structlog.getLogger("hubuum.object")
 migration_logger = structlog.getLogger("hubuum.migration")
 
 
@@ -35,7 +34,7 @@ def _log_user_event(
     if user:
         user_label = cast(int, user.id)
 
-    user_logger.bind(id=user_label, request_id=get_request_id()).log(level, event)
+    user_logger.bind(id=user_label).log(level, event)
 
 
 def _identifier(instance: object) -> str:
@@ -54,17 +53,11 @@ def log_object_creation(
     model_name = cast(str, sender.__name__)
     if created:
         if model_name == "Migration":
-            migration_logger.bind(
-                model=model_name, request_id=get_request_id(), id=identifier
-            ).debug("created")
+            migration_logger.bind(model=model_name, id=identifier).debug("created")
         else:
-            object_logger.bind(
-                model=sender.__name__, request_id=get_request_id(), id=identifier
-            ).info("created")
+            object_logger.bind(model=sender.__name__, id=identifier).info("created")
     else:
-        object_logger.bind(
-            model=sender.__name__, request_id=get_request_id(), id=identifier
-        ).info("updated")
+        object_logger.bind(model=sender.__name__, id=identifier).info("updated")
 
 
 @receiver(post_delete)
@@ -72,9 +65,7 @@ def log_object_deletion(
     sender: Model, instance: object, **kwargs: Dict[str, Any]
 ) -> None:
     """Log object deletion."""
-    object_logger.bind(
-        model=sender.__name__, request_id=get_request_id(), id=_identifier(instance)
-    ).info("deleted")
+    object_logger.bind(model=sender.__name__, id=_identifier(instance)).info("deleted")
 
 
 @receiver(user_logged_in)
@@ -108,7 +99,6 @@ def auto_delete_file_on_delete(
     """
     object_logger.bind(
         model=sender.__name__,
-        request_id=get_request_id(),
         id=_identifier(instance),
         sha256=instance.sha256,
         path=instance.attachment.path,

--- a/hubuum/tests/test_00_internals.py
+++ b/hubuum/tests/test_00_internals.py
@@ -161,7 +161,6 @@ class InternalsTestCase(HubuumModelTestCase):
 
     def test_request_color_tracker(self) -> None:
         """Test that the request color tracker works as expected."""
-
         color_tracker = RequestColorTracker()
 
         events = [

--- a/hubuum/tests/test_00_internals.py
+++ b/hubuum/tests/test_00_internals.py
@@ -5,7 +5,7 @@ import pytest
 from rest_framework.exceptions import NotFound, ValidationError
 
 from hubuum.exceptions import InvalidParam, MissingParam
-from hubuum.log import filter_sensitive_data
+from hubuum.log import RequestColorTracker, filter_sensitive_data
 from hubuum.models.core import model_supports_attachments, model_supports_extensions
 from hubuum.models.iam import (
     Namespace,
@@ -155,3 +155,35 @@ class InternalsTestCase(HubuumModelTestCase):
 
         with pytest.raises(InvalidParam):
             filter_sensitive_data(None, None, Host)
+
+    def test_request_color_generator(self):
+        """Test that the request color generator works."""
+
+    def test_request_color_tracker(self) -> None:
+        """Test that the request color tracker works as expected."""
+
+        color_tracker = RequestColorTracker()
+
+        events = [
+            {"request_id": "abc123", "event": "Event 1"},
+            {"request_id": "def456", "event": "Event 2"},
+            {"request_id": "abc123", "event": "Event 3"},
+            {"request_id": "abc123", "event": "Event 3"},
+            {"request_id": "ghi789", "event": "Event 3"},
+        ]
+
+        expected_colors = [
+            color_tracker.COLORS[0],
+            color_tracker.COLORS[1],
+            color_tracker.COLORS[0],
+            color_tracker.COLORS[0],
+            color_tracker.COLORS[2],
+        ]
+
+        for i, event in enumerate(events):
+            expected_color = expected_colors[i]
+            colored_bubble = color_tracker._colorize(expected_color, " • ")
+            expected_event = colored_bubble + event["event"]
+            colored_event = color_tracker(None, None, event)
+
+            self.assertEqual(colored_event["event"], expected_event)

--- a/hubuum/tests/test_01_configuration_management.py
+++ b/hubuum/tests/test_01_configuration_management.py
@@ -8,7 +8,7 @@ import pytest
 import structlog
 from django.test import TestCase
 
-from hubuumsite.config.abstract import valid_logging_levels
+from hubuumsite.config.abstract import HubuumAbstractConfig, valid_logging_levels
 from hubuumsite.config.base import HubuumBaseConfig
 from hubuumsite.config.database import HubuumDatabaseConfig
 from hubuumsite.config.logging import HubuumLoggingConfig
@@ -224,6 +224,7 @@ class HubuumBaseConfigTestCase(TestCase):
                 "HUBUUM_LOGGING_LEVEL",
                 "HUBUUM_LOGGING_PRODUCTION",
                 "HUBUUM_LOGGING_BODY_LENGTH",
+                "HUBUUM_LOGGING_COLLAPSE_REQUEST_ID",
                 "HUBUUM_LOGGING_LEVEL_API",
                 "HUBUUM_LOGGING_LEVEL_AUTH",
                 "HUBUUM_LOGGING_LEVEL_OBJECT",
@@ -246,3 +247,24 @@ class HubuumBaseConfigTestCase(TestCase):
                 "HUBUUM_SENTRY_ENVIRONMENT",
             ],
         )
+
+    def test_get_prefixed_pairs_creating_booleans(self):
+        # Define the environment
+        env = {
+            "HUBUUM_PREFIX_KEY1": "false",
+            "HUBUUM_PREFIX_KEY2": "true",
+            "HUBUUM_PREFIX_KEY3": "value",
+        }
+
+        self.obj = HubuumAbstractConfig("PREFIX", env)
+
+        # Set VALID_KEYS in your object
+        self.obj.VALID_KEYS = {"KEY1": None, "KEY2": None, "KEY3": None}
+
+        # Run your function
+        result = self.obj.get_prefixed_pairs("PREFIX", env)
+
+        # Assert that the values are as expected
+        self.assertEqual(result["HUBUUM_PREFIX_KEY1"], False)
+        self.assertEqual(result["HUBUUM_PREFIX_KEY2"], True)
+        self.assertEqual(result["HUBUUM_PREFIX_KEY3"], "value")

--- a/hubuum/tests/test_01_configuration_management.py
+++ b/hubuum/tests/test_01_configuration_management.py
@@ -249,6 +249,7 @@ class HubuumBaseConfigTestCase(TestCase):
         )
 
     def test_get_prefixed_pairs_creating_booleans(self):
+        """Test that configuration booleans work."""
         # Define the environment
         env = {
             "HUBUUM_PREFIX_KEY1": "false",

--- a/hubuum/tests/test_01_configuration_management.py
+++ b/hubuum/tests/test_01_configuration_management.py
@@ -131,17 +131,17 @@ class HubuumBaseConfigTestCase(TestCase):
         """Test the logging output types for structlog."""
         # Default is JSON
         config = self._create_config()
-        logging_type = config.logging.get_logging_output_type()
+        logging_type = config.logging.get_logging_output()[-1]
         self.assertIsInstance(logging_type, structlog.dev.ConsoleRenderer)
 
         # Explicitly set to JSON
         config = self._create_config(HUBUUM_LOGGING_PRODUCTION=False)
-        logging_type = config.logging.get_logging_output_type()
+        logging_type = config.logging.get_logging_output()[-1]
         self.assertIsInstance(logging_type, structlog.dev.ConsoleRenderer)
 
         # Explicitly set to produciton
         config = self._create_config(HUBUUM_LOGGING_PRODUCTION=True)
-        logging_type = config.logging.get_logging_output_type()
+        logging_type = config.logging.get_logging_output()[-1]
         self.assertIsInstance(logging_type, structlog.processors.JSONRenderer)
 
     def test_testing_parallel(self) -> None:
@@ -223,15 +223,16 @@ class HubuumBaseConfigTestCase(TestCase):
             [
                 "HUBUUM_LOGGING_LEVEL",
                 "HUBUUM_LOGGING_PRODUCTION",
+                "HUBUUM_LOGGING_BODY_LENGTH",
                 "HUBUUM_LOGGING_LEVEL_API",
                 "HUBUUM_LOGGING_LEVEL_AUTH",
-                "HUBUUM_LOGGING_LEVEL_DJANGO",
+                "HUBUUM_LOGGING_LEVEL_OBJECT",
+                "HUBUUM_LOGGING_LEVEL_HTTP",
+                "HUBUUM_LOGGING_LEVEL_SIGNAL",
                 "HUBUUM_LOGGING_LEVEL_INTERNAL",
                 "HUBUUM_LOGGING_LEVEL_MANUAL",
+                "HUBUUM_LOGGING_LEVEL_DJANGO",
                 "HUBUUM_LOGGING_LEVEL_MIGRATION",
-                "HUBUUM_LOGGING_LEVEL_REQUEST",
-                "HUBUUM_LOGGING_LEVEL_RESPONSE",
-                "HUBUUM_LOGGING_LEVEL_SIGNALS",
             ],
         )
 

--- a/hubuumsite/config/abstract.py
+++ b/hubuumsite/config/abstract.py
@@ -61,7 +61,15 @@ class HubuumAbstractConfig:
             if "LEVEL" in key and isinstance(value, str):
                 value = value.upper()
 
-            prefixed_pairs[fq_key] = value
+            if isinstance(value, str):
+                if value.lower() == "false":
+                    prefixed_pairs[fq_key] = False
+                elif value.lower() == "true":
+                    prefixed_pairs[fq_key] = True
+                else:
+                    prefixed_pairs[fq_key] = value
+            else:
+                prefixed_pairs[fq_key] = value
 
         return prefixed_pairs
 

--- a/hubuumsite/settings.py
+++ b/hubuumsite/settings.py
@@ -12,9 +12,10 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 import os
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 import structlog
+from structlog.types import Processor
 from structlog_sentry import SentryProcessor
 
 import hubuum.log
@@ -34,6 +35,8 @@ REQUESTS_LOG_LEVEL_SLOW = config.requests.get_log_level("LOG_LEVEL_SLOW")
 REQUESTS_THRESHOLD_VERY_SLOW = config.requests.get("THRESHOLD_VERY_SLOW")
 REQUESTS_LOG_LEVEL_VERY_SLOW = config.requests.get_log_level("LOG_LEVEL_VERY_SLOW")
 
+LOGGING_MAX_BODY_LENGTH = config.logging.get("BODY_LENGTH")
+
 # from rest_framework.settings import api_settings
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -42,6 +45,9 @@ BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 ALLOWED_HOSTS = []
+
+# Apply a / if needed
+APPEND_SLASH = True
 
 # Application definition
 INSTALLED_APPS = [
@@ -62,8 +68,7 @@ INSTALLED_APPS = [
 AUTH_USER_MODEL = "hubuum.User"
 
 MIDDLEWARE = [
-    "django_structlog.middlewares.RequestMiddleware",
-    "hubuum.middleware.logging_http.LogHttpResponseMiddleware",
+    "hubuum.middleware.context.ContextMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -71,7 +76,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "hubuum.middleware.context.ContextMiddleware",
+    "django_structlog.middlewares.RequestMiddleware",
+    "hubuum.middleware.logging_http.LogHttpResponseMiddleware",
 ]
 
 ROOT_URLCONF = "hubuumsite.urls"
@@ -171,22 +177,28 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = "/static/"
+
+# Prepare a variable for the common processors
+processors: List[
+    Union[Processor, structlog.dev.ConsoleRenderer, structlog.processors.JSONRenderer]
+] = [
+    hubuum.log.filter_sensitive_data,
+    structlog.stdlib.filter_by_level,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    structlog.processors.TimeStamper(fmt="iso"),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.UnicodeDecoder(),
+    SentryProcessor(event_level=config.sentry.get_log_level("SENTRY_LEVEL")),
+]
+
+# Append the final renderer (either JSON or Console), and any additional processors
+processors.extend(config.logging.get_logging_output())
+
 structlog.configure(
-    processors=[
-        hubuum.log.filter_sensitive_data,
-        structlog.stdlib.filter_by_level,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.UnicodeDecoder(),
-        SentryProcessor(event_level=config.sentry.get_log_level("SENTRY_LEVEL")),
-        # This sets either consolelogger or jsonlogger as the output type,
-        # depending on if we're running in prod or testing production logging.
-        config.logging.get_logging_output_type(),
-    ],
+    processors=processors,
     context_class=dict,
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
@@ -218,24 +230,24 @@ LOGGING: Dict[str, Any] = {
             "handlers": ["console"],
             "level": config.logging.level_for_source("INTERNAL"),
         },
-        "hubuum.api.object": {
+        "hubuum.api": {
             "handlers": ["console"],
             "level": config.logging.level_for_source("API"),
             "propagate": False,
         },
-        "hubuum.signals.object": {
+        "hubuum.object": {
             "handlers": ["console"],
-            "level": config.logging.level_for_source("SIGNALS"),
+            "level": config.logging.level_for_source("OBJECT"),
             "propagate": False,
         },
-        "hubuum.request": {
+        "hubuum.signal": {
             "handlers": ["console"],
-            "level": config.logging.level_for_source("REQUEST"),
+            "level": config.logging.level_for_source("SIGNAL"),
             "propagate": False,
         },
-        "hubuum.response": {
+        "hubuum.http": {
             "handlers": ["console"],
-            "level": config.logging.level_for_source("RESPONSE"),
+            "level": config.logging.level_for_source("HTTP"),
             "propagate": False,
         },
         "hubuum.auth": {

--- a/hubuumsite/settings.py
+++ b/hubuumsite/settings.py
@@ -229,6 +229,7 @@ LOGGING: Dict[str, Any] = {
         "hubuum.internal": {
             "handlers": ["console"],
             "level": config.logging.level_for_source("INTERNAL"),
+            "propagate": False,
         },
         "hubuum.api": {
             "handlers": ["console"],


### PR DESCRIPTION
  - Request_ID is now added by the structlog processor add_request_id
  - Request_ID is now guaranteed to be first in the key list during console output, curtesy of the structlog processor reorder_keys_processor
  - Request_ID is collapsed during console output curtesy of the structlog processor collapse_request_id
  - To facilitate easy visual tracking of request_ids, a colored dot prefixes the log event field, and the same request_id the dot will have a given color.
  - Renaming and reworking the loggers, updated documentation.
  - Fixed issue for assigning booleans via the environment.